### PR TITLE
add config vars to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,37 @@
     "SOURCE_URL": {
       "required": true
     },
-    "PR_APP": "true"
+
+    "PR_APP": "true",
+
+    "DURATION": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "INCIDENT_ID": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "STATE": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "TITLE": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "STARTED_AT": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "INCIDENT_ID": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    },
+    "REVIEW": {
+      "description": "field name to use when syncing incidents from an external data source",
+      "required": false
+    }
   },
   "formation": {
     "web": {


### PR DESCRIPTION
This adds some of the settings from config.rb to app.json as optional params.  Adding them to app.json causes Heroku to inherit them from the template app (`retrodot-staging`) when creating a PR app.  We need this so that we can inherit heroku-specific custom variable values into our PR apps.

Setting `required = false` ensures that the PR app can be created without those values being set.