### PR TITLE
restore .env.sample removed in #23

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+export SOURCE_URL="http://localhost"


### PR DESCRIPTION
#23 removed `.env.sample` (perhaps mistakenly?).  #29 also proposed to remove `.env.sample` and fixed `.travis.yml` to compensate.  #29 was since closed so Travis remains broken by #23 (it tries to copy `.env.sample` to `.env` and fails).

This PR restores `.env.sample` to fix travis.