### PR TITLE
"start incident" command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 log
 
 *.swp
+*.kate-swp
 .env
 .env.test
 .env.development

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'jquery-rails'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem "haml-rails", "~> 0.9"
+gem "chronic"
 
 gem "excon", "0.50.1"
 gem "configerator"

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ end
 
 group :test do
   gem 'webmock', require: 'webmock/rspec'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       thor (~> 0.19)
     builder (3.2.2)
     byebug (9.0.5)
+    chronic (0.10.2)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -307,6 +308,7 @@ DEPENDENCIES
   active_record_ignored_attributes
   activeadmin (~> 1.0.0.pre4)
   byebug
+  chronic
   coffee-rails (~> 4.2)
   configerator
   database_cleaner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timecop (0.8.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -335,6 +336,7 @@ DEPENDENCIES
   shoulda
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   webmock

--- a/app.json
+++ b/app.json
@@ -48,7 +48,7 @@
       "description": "field name to use when syncing incidents from an external data source",
       "required": false
     },
-    "INCIDENT_ID": {
+    "RESOLVED_AT": {
       "description": "field name to use when syncing incidents from an external data source",
       "required": false
     },

--- a/app/controllers/api/v1/chat_ops_controller.rb
+++ b/app/controllers/api/v1/chat_ops_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::ChatOpsController < ApplicationController
   end
 
   def respond
-    user = User.ensure(**params['user'].slice('email', 'name', 'handle').symbolize_keys)
+    user = User.ensure(**params.permit(user: [:email, :name, :handle])[:user].to_h.symbolize_keys)
     result = ChatOps.process(user, params['message'])
 
     if result

--- a/app/controllers/api/v1/chat_ops_controller.rb
+++ b/app/controllers/api/v1/chat_ops_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::ChatOpsController < ApplicationController
   end
 
   def respond
-    result = ChatOps.process(params['user'], params['message'])
+    user = User.ensure(**params['user'].slice('email', 'name', 'handle').symbolize_keys)
+    result = ChatOps.process(user, params['message'])
 
     if result
       render json: result

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -4,4 +4,7 @@ class Incident < ActiveRecord::Base
   belongs_to :category
   has_many :timeline_entries
   has_and_belongs_to_many :responders, join_table: :incidents_responders, class_name: "User"
+
+  default_scope { order('incident_id DESC') }
+  scope :open, -> { where(state: "open") }
 end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -8,6 +8,7 @@ class Incident < ActiveRecord::Base
   default_scope { order('incident_id DESC') }
   scope :open, -> { where(state: "open") }
   scope :synced, -> { where.not(last_sync: nil) }
+  scope :by_timeline_start, -> { unscoped.where.not(timeline_start: nil).order('timeline_start DESC') }
 
   def chat_start
     super&.in_time_zone Config.time_zone

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -10,10 +10,10 @@ class Incident < ActiveRecord::Base
   scope :synced, -> { where.not(last_sync: nil) }
 
   def chat_start
-    super.in_time_zone Config.time_zone
+    super&.in_time_zone Config.time_zone
   end
 
   def chat_end
-    super.in_time_zone Config.time_zone
+    super&.in_time_zone Config.time_zone
   end
 end

--- a/app/models/incident.rb
+++ b/app/models/incident.rb
@@ -7,4 +7,13 @@ class Incident < ActiveRecord::Base
 
   default_scope { order('incident_id DESC') }
   scope :open, -> { where(state: "open") }
+  scope :synced, -> { where.not(last_sync: nil) }
+
+  def chat_start
+    super.in_time_zone Config.time_zone
+  end
+
+  def chat_end
+    super.in_time_zone Config.time_zone
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,13 @@ class User < ApplicationRecord
       handle: handle
     }
   end
+
+  class << self
+    def ensure(email:, name: nil, handle: nil)
+      user = find_or_create_by(email: email)
+      user.name = name
+      user.handle = handle
+      user.save!
+    end
+  end
 end

--- a/app/support/mediators/incident/persister.rb
+++ b/app/support/mediators/incident/persister.rb
@@ -14,7 +14,7 @@ module Mediators::Incident
     def update_incident
       Rails.logger.info(fn: "update_incident")
       incident = ::Incident.find_or_initialize_by(incident_id: parse_details[:incident_id])
-      incident.update(parse_details.merge!(followup_on: followup_date))
+      incident.update(parse_details.merge!(followup_on: followup_date, last_sync: Time.now))
     end
 
     def parse_details

--- a/app/support/mediators/incident/persister.rb
+++ b/app/support/mediators/incident/persister.rb
@@ -26,7 +26,7 @@ module Mediators::Incident
 
     private
     def followup_date
-      Config.followup_days.days.from_now(DateTime.parse(parse_details[:started_at])) if parse_details[:review]
+      Config.followup_days.days.from_now(DateTime.parse(parse_details[:started_at])) if parse_details[:review] and parse_details[:started_at]
     end
 
     def details

--- a/app/support/mediators/user/sync.rb
+++ b/app/support/mediators/user/sync.rb
@@ -3,10 +3,7 @@ module Mediators::User
     def call
       users.each do |chatops_user|
         if chatops_user['email']
-          user = ::User.find_or_initialize_by(email: chatops_user['email'])
-          user.name = chatops_user['name'] || ""
-          user.handle = chatops_user['handle']
-          user.save!
+          User.ensure(**chatops_user.slice('email', 'name', 'handle').symbolize_keys)
         end
       end
     end

--- a/config/config.rb
+++ b/config/config.rb
@@ -10,6 +10,7 @@ module Config
   required :source_url, string
   override :app_name, "retrodot", string
   override :frontend_host, "retro.dev", string
+  override :time_zone, "US/Pacific", string
 
   # Overrides for incident syncher
   override :duration, "duration", string

--- a/db/migrate/20160908150249_change_users.rb
+++ b/db/migrate/20160908150249_change_users.rb
@@ -1,0 +1,6 @@
+class ChangeUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null(:users, :name, true)
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20160908173255_add_timeline_start_and_last_sync_to_incident.rb
+++ b/db/migrate/20160908173255_add_timeline_start_and_last_sync_to_incident.rb
@@ -1,0 +1,9 @@
+class AddTimelineStartAndLastSyncToIncident < ActiveRecord::Migration[5.0]
+  def change
+    add_column :incidents, :timeline_start, :datetime
+    add_index :incidents, :timeline_start
+
+    add_column :incidents, :last_sync, :datetime
+    add_index :incidents, :last_sync
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160908150249) do
+ActiveRecord::Schema.define(version: 20160908173255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,12 +42,16 @@ ActiveRecord::Schema.define(version: 20160908150249) do
     t.integer  "incident_id"
     t.boolean  "review"
     t.date     "followup_on"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
     t.integer  "category_id"
     t.datetime "chat_start"
     t.datetime "chat_end"
+    t.datetime "timeline_start"
+    t.datetime "last_sync"
     t.index ["category_id"], name: "index_incidents_on_category_id", using: :btree
+    t.index ["last_sync"], name: "index_incidents_on_last_sync", using: :btree
+    t.index ["timeline_start"], name: "index_incidents_on_timeline_start", using: :btree
   end
 
   create_table "incidents_responders", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160831174453) do
+ActiveRecord::Schema.define(version: 20160908150249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,10 +91,11 @@ ActiveRecord::Schema.define(version: 20160831174453) do
 
   create_table "users", force: :cascade do |t|
     t.text     "email",      null: false
-    t.text     "name",       null: false
+    t.text     "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "handle"
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["handle"], name: "index_users_on_handle", using: :btree
   end
 

--- a/lib/chat_ops/chat_ops.rb
+++ b/lib/chat_ops/chat_ops.rb
@@ -21,6 +21,11 @@ module ChatOps
       Regexp.union(commands.collect(&:regex))
     end
 
+    # Get a help message describing each command.
+    def help
+      commands.map(&:help).reject(&:blank?).join("\n")
+    end
+
     # Try to process a message as a ChatOps command.  Return nil if no
     # command matched.  TODO: define return value for success.
     def process(user, message)

--- a/lib/chat_ops/chat_ops_command.rb
+++ b/lib/chat_ops/chat_ops_command.rb
@@ -24,8 +24,19 @@ class ChatOpsCommand
     end
   end
 
+  # Implement run() in the subclass.  It should return a hash describing the
+  # response.  The hash may contain the following keys:
+  #
+  #   message: (optional) text to reply back with
+  #   subject: (optional) a subject line for an extended message, e.g. Slack's
+  #     "attachments"
+  #   reaction: (optional) name of an emoji to add as a reaction to the user's
+  #     message
+  #
+  # Return nil to indicate that we don't actually want to process the command
+  # after all.
+
   def run(user, message)
-    # define in subclass
-    {"error": "command not implemented"}
+    nil
   end
 end

--- a/lib/chat_ops/chat_ops_command.rb
+++ b/lib/chat_ops/chat_ops_command.rb
@@ -13,10 +13,6 @@ class ChatOpsCommand
       @regex = r
     end
 
-    def name(n)
-      @name = n
-    end
-
     def help_message(text)
       @help = text
     end

--- a/lib/chat_ops/chat_ops_command.rb
+++ b/lib/chat_ops/chat_ops_command.rb
@@ -1,6 +1,6 @@
 class ChatOpsCommand
   class << self
-    attr_reader :regex, :name
+    attr_reader :regex, :name, :help
 
     # Ruby calls this function when a class is declared that inherits from this
     # class.  We then register it with the ChatOps module.
@@ -15,6 +15,10 @@ class ChatOpsCommand
 
     def name(n)
       @name = n
+    end
+
+    def help_message(text)
+      @help = text
     end
   end
 
@@ -36,7 +40,7 @@ class ChatOpsCommand
   # Return nil to indicate that we don't actually want to process the command
   # after all.
 
-  def run(user, message)
+  def run(user, match_data)
     nil
   end
 end

--- a/lib/chat_ops/commands/start_incident_command.rb
+++ b/lib/chat_ops/commands/start_incident_command.rb
@@ -1,25 +1,24 @@
 class StartIncidentCommand < ChatOpsCommand
   match %r{
           # allow "start incident" or "start an incident"
-          start\s+(an\s+)?incident\s+
+          start\s+(an\s+)?incident
+          (\s+
+            (
+              # if they specify an incident ID, use that.
+              (?<incident_id>\d+)
 
+              # incident ID must be followed by whitespace
+              \s+
 
-          (
-            # if they specify an incident ID, use that.
-            (?<incident_id>\d+)
+              # Don't match incident #14 in "start an incident 14 minutes ago"
+              (?!(seconds|minutes|hours)\s+ago)
 
-            # incident ID must be followed by whitespace
-            \s+
+            )?
 
-            # Don't match incident #14 in "start an incident 14 minutes ago"
-            (?!\s+(seconds|minutes|hours)\s+ago)
-
+            # Slurp up the remainder.  IncidentResponse.parse_timestamp will
+            # parse it as a timestamp specified in natural language.
+            (?<timestamp>.*)
           )?
-
-          # Slurp up the remainder.  IncidentResponse.parse_timestamp will
-          # parse it as a timestamp specified in natural language.
-          (?<timestamp>.*)
-
           $
         }ix
 
@@ -65,14 +64,13 @@ class StartIncidentCommand < ChatOpsCommand
       incident_id = 1
     end
 
-
+    incident_id
   end
 
   def get_chat_start(timestamp=nil)
+    puts timestamp
     if timestamp
-      IncidentResponse.parse_timestamp(timestamp)
-    else
-      Time.now
-    end
+      ::IncidentResponse.parse_timestamp(timestamp)
+    end || Time.now
   end
 end

--- a/lib/chat_ops/commands/start_incident_command.rb
+++ b/lib/chat_ops/commands/start_incident_command.rb
@@ -1,3 +1,78 @@
 class StartIncidentCommand < ChatOpsCommand
-  match /start( an)? incident/
+  match %r{
+          # allow "start incident" or "start an incident"
+          start\s+(an\s+)?incident\s+
+
+
+          (
+            # if they specify an incident ID, use that.
+            (?<incident_id>\d+)
+
+            # incident ID must be followed by whitespace
+            \s+
+
+            # Don't match incident #14 in "start an incident 14 minutes ago"
+            (?!\s+(seconds|minutes|hours)\s+ago)
+
+          )?
+
+          # Slurp up the remainder.  IncidentResponse.parse_timestamp will
+          # parse it as a timestamp specified in natural language.
+          (?<timestamp>.*)
+
+          $
+        }ix
+
+  help_message "h start incident [#] [at <timespec>] - sets or overwrites incident start time (timespec examples: 5 minutes ago, 3pm, etc)"
+
+  def run(user, match)
+    incident_id = infer_incident_id(match[:incident_id])
+    chat_start = get_chat_start(match[:timestamp]).in_time_zone(Config.time_zone)
+
+    message = ["Recorded the start of chat for incident \##{incident_id} at #{chat_start.inspect}"]
+
+    incident = Incident.find_or_create_by(incident_id: incident_id)
+
+    if incident.chat_start
+      message << "     (overwriting start time for incident \##{incident_id}, was: #{incident.chat_start.inspect})"
+    end
+
+    incident.timeline_start = Time.now
+    incident.chat_start = get_chat_start(match[:timestamp])
+    incident.responders << user
+    incident.save
+
+    ChatOps.help.each_line do |line|
+      message << "  " + line
+    end
+
+    { message: message.join("\n") }
+  end
+
+  private
+  def infer_incident_id(incident_id=nil)
+    # If they specified an incident ID, use it.
+    # Otherwise, if an incident is open, they probably mean that one.
+    incident_id = Incident.open.first if !incident_id
+
+    # If no incident is open, they probably mean the ID of the next incident to
+    # be opened.
+    begin
+      incident_id = Incident.synced.first.incident_id + 1 if !incident_id
+    rescue NoMethodError
+      # If no incidents have been opened yet, we would have tried to do
+      # nil + 1, which would raise NoMethodError.  Default to 1.
+      incident_id = 1
+    end
+
+
+  end
+
+  def get_chat_start(timestamp=nil)
+    if timestamp
+      IncidentResponse.parse_timestamp(timestamp)
+    else
+      Time.now
+    end
+  end
 end

--- a/lib/incident_response.rb
+++ b/lib/incident_response.rb
@@ -69,7 +69,7 @@ module IncidentResponse
     end
 
     def in_dst?
-      Time.use_zone(Config.zone) { Time.zone.now.isdst }
+      Time.use_zone(Config.time_zone) { Time.zone.now.isdst }
     end
 
     def normalize_name(name)

--- a/lib/incident_response.rb
+++ b/lib/incident_response.rb
@@ -20,7 +20,58 @@ module IncidentResponse
       end
     end
 
+    # Parse a timestamp specified in natural language.
+    def parse_timestamp(timestamp)
+      Time.use_zone(Config.time_zone) do
+        Chronic.time_class = Time.zone
+
+        # Chronic likes "today at 3pm" but not "at 3pm".
+        timestamp.sub! /^at /, ''
+
+        result = Chronic.parse(timestamp)
+
+        # The presence of a time zone causes Chronic to return nil in all but a
+        # few select formats.  https://github.com/mojombo/chronic/issues/134
+        # Work around that bug by stripping off the time zone, parsing, then
+        # pasting it back on and parsing again.
+        if !result
+          timestamp.sub! /\s+(\S+)$/, ''
+          tz = fix_dst($1.upcase)
+
+          return unless result = Chronic.parse(timestamp)
+
+          result = Chronic.parse(result.strftime("%F %T #{tz}"))
+        end
+
+        return result
+      end
+    end
+
     private
+    # If passed "EST" during daylight time, return "EDT", and the reverse.
+    # People often say "3pm EST" when it's technically "3pm EDT" during that
+    # part of the year.
+    def fix_dst(tz)
+      tz = tz.dup
+
+      case tz
+        when /DT$/i
+          # All *DT time zones match up with the corresponding -ST time zone.  For
+          # Example, EDT -> EST
+          tz.sub! /DT$/i, 'ST' if !in_dst?
+        when /[PMCE]ST$/i
+          # NOT all *ST time zones match up with a corresponding -DT time zone.
+          # For example, CEST -> CET.
+          tz.sub! /ST$/i, 'DT' if in_dst?
+      end
+
+      tz
+    end
+
+    def in_dst?
+      Time.use_zone(Config.zone) { Time.zone.now.isdst }
+    end
+
     def normalize_name(name)
       name.downcase.strip.gsub(/\s+/, ' ')
     end

--- a/spec/controllers/api/v1/chat_ops_controller_spec.rb
+++ b/spec/controllers/api/v1/chat_ops_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Api::V1::ChatOpsController do
     it "calls ChatOps.process" do
       expect(ChatOps).to receive(:process).exactly(1).times
       basic_auth "api", Config.chatops_api_key
-      get :respond
+      post :respond, params: {user: {email: "test", handle: "test", name: "test"}}
 
       # 404 because no command matches our (blank) message
       expect(response).to have_http_status(:not_found)

--- a/spec/factories/incident.rb
+++ b/spec/factories/incident.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :incident do
+    sequence(:incident_id) {|n| n}
+    title "incident title"
+    state "open"
+    chat_start { Time.now }
+    chat_end { Time.now }
+    timeline_start { Time.now }
+  end
+end

--- a/spec/factories/incident.rb
+++ b/spec/factories/incident.rb
@@ -1,10 +1,22 @@
 FactoryGirl.define do
   factory :incident do
+    transient do
+      open false
+    end
+
     sequence(:incident_id) {|n| n}
     title "incident title"
-    state "open"
+    state "resolved"
     chat_start { Time.now }
     chat_end { Time.now }
-    timeline_start { Time.now }
+    timeline_start nil
+
+    trait :synced do
+      last_sync { Time.now }
+    end
+
+    after(:create) do |incident, evaluator|
+      incident.update(state: "open") if evaluator.open
+    end
   end
 end

--- a/spec/lib/chat_ops/chat_ops_spec.rb
+++ b/spec/lib/chat_ops/chat_ops_spec.rb
@@ -3,6 +3,9 @@ RSpec.describe ChatOps do
   before { ChatOps.class_variable_set :@@commands, [] }
   after { ChatOps.class_variable_set :@@commands, commands }
 
+  let(:cmd_1_class) { Class.new(ChatOpsCommand) }
+  let(:cmd_2_class) { Class.new(ChatOpsCommand) }
+
   describe '.register' do
     it 'adds class to commands class variable' do
       Foo = Class.new
@@ -19,17 +22,11 @@ RSpec.describe ChatOps do
     end
 
     it 'registers when some class inherits from ChatOpsCommand' do
-      TestCommand1 = Class.new(ChatOpsCommand)
-      TestCommand2 = Class.new(ChatOpsCommand)
-
-      expect(ChatOps.commands).to include TestCommand1, TestCommand2
+      expect(ChatOps.commands).to include cmd_1_class, cmd_2_class
     end
   end
 
   describe '.matcher' do
-    let(:cmd_1_class) { Class.new(ChatOpsCommand) }
-    let(:cmd_2_class) { Class.new(ChatOpsCommand) }
-
     it 'builds a regex from defined commands' do
       cmd_1_class.class_eval { match /test_regex1_[0-9]+/ }
       cmd_2_class.class_eval { match /test_regex2_[a-z]+/ }
@@ -39,9 +36,11 @@ RSpec.describe ChatOps do
     end
   end
 
+  describe '.help' do
+
+  end
+
   describe '.process' do
-    let(:cmd_1_class) { Class.new(ChatOpsCommand) }
-    let(:cmd_2_class) { Class.new(ChatOpsCommand) }
     let!(:cmd_1_instance) { cmd_1_class.new }
     let!(:cmd_2_instance) { cmd_2_class.new }
 

--- a/spec/lib/chat_ops/chat_ops_spec.rb
+++ b/spec/lib/chat_ops/chat_ops_spec.rb
@@ -37,7 +37,21 @@ RSpec.describe ChatOps do
   end
 
   describe '.help' do
+    let(:help1) { "command 1 help text" }
+    let(:help2) { "command 2 help text" }
 
+    it "joins all commands' help messages with newlines" do
+      cmd_1_class.class_eval "help_message '#{help1}'"
+      cmd_2_class.class_eval "help_message '#{help2}'"
+
+      expect(ChatOps.help).to include help1, help2
+    end
+
+    it "skips classes that don't specify a help message" do
+      cmd_1_class.class_eval "help_message '#{help1}'"
+
+      expect(ChatOps.help).to eq help1
+    end
   end
 
   describe '.process' do

--- a/spec/lib/chat_ops/commands/start_incident_command_spec.rb
+++ b/spec/lib/chat_ops/commands/start_incident_command_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe ChatOps::Commands::StartIncidentCommand do
+  describe "regex" do
+    let(:regex) {  }
+
+    example_commands = <<-EOL.each_line.map(&:strip)
+      start incident
+      start an incident
+      start incident 900
+      start an incident at 09:30
+      start an incident 5 minutes ago
+      start incident 300 5 minutes ago
+    EOL
+
+    subject { ChatOps::Commands::StartIncidentCommand.regex }
+
+    example_commands.each do |command|
+      it { is_expected.to match command }
+    end
+  end
+
+  describe ".run" do
+    let(:start_incident_command) { ChatOps::Commands::StartIncidentCommand.new }
+    let(:user) { create(:user) }
+
+    def process(command)
+      start_incident_command.process(user, command)
+    end
+
+    def last_incident
+      Incident.by_timeline_start.first
+    end
+
+    def last_incident_id
+      last_incident.incident_id
+    end
+
+    def start_incident(arg="")
+      process("start incident #{arg}")
+    end
+
+    it "picks incident id 1 if no incidents exist" do
+      process("start incident")
+      expect(last_incident_id).to eq 1
+    end
+
+    it "picks the latest open incident if one exists" do
+      create(:incident, :synced, incident_id: 1)
+      create(:incident, :synced, open: true, incident_id: 2)
+
+      start_incident
+
+      expect(last_incident_id).to eq 2
+    end
+
+    it "picks the next available incident id if no incident is open" do
+      create(:incident, :synced, incident_id: 1)
+      create(:incident, :synced, incident_id: 2)
+
+      start_incident
+
+      expect(last_incident_id).to eq 3
+    end
+
+    it "only considers synced incidents" do
+      create(:incident, :synced, incident_id: 1)
+      create(:incident, incident_id: 2)
+
+      start_incident
+
+      expect(last_incident_id).to eq 2
+    end
+
+    it "sets chat start to the current time when no time is specified" do
+      Timecop.freeze do
+        start_incident
+        expect(last_incident.chat_start).to be_within(0.001).of Time.now
+      end
+    end
+
+    it "overwrites chat start when run a second time" do
+      Timecop.freeze 10.minutes.ago do
+        start_incident
+      end
+
+      first_incident_id = last_incident_id
+
+      Timecop.freeze do
+        start_incident
+
+        expect(last_incident.chat_start).to be_within(0.001).of Time.now
+      end
+
+      expect(last_incident_id).to eq first_incident_id
+    end
+
+    it "uses the timestamp provided" do
+      Timecop.freeze do
+        start_incident "ten minutes ago"
+        expect(last_incident.chat_start).to be_within(0.001).of 10.minutes.ago
+      end
+    end
+
+    it "allows the user to specify the incident id" do
+      start_incident "14"
+      expect(last_incident_id).to eq 14
+    end
+
+    it "properly handles 'start an incident 14 minutes ago'" do
+      Timecop.freeze do
+        start_incident "14 minutes ago"
+        expect(last_incident_id).not_to eq 14
+        expect(last_incident.chat_start).to be_within(0.001).of 14.minutes.ago
+      end
+    end
+  end
+end

--- a/spec/lib/incident_response_spec.rb
+++ b/spec/lib/incident_response_spec.rb
@@ -89,4 +89,55 @@ RSpec.describe IncidentResponse do
       expect(IncidentResponse.prevent_highlights(before)).to eq after
     end
   end
+
+  describe ".parse_timestamp" do
+    before(:each) do
+      allow(Config).to receive(:time_zone).and_return('US/Pacific')
+    end
+
+    let(:date_in_dst) do
+      ActiveSupport::TimeZone[Config.time_zone].parse('2016-09-07 05:00:00 PDT')
+    end
+
+    let(:date_not_in_dst) do
+      ActiveSupport::TimeZone[Config.time_zone].parse('2015-12-07 05:00:00 PDT')
+    end
+
+    let(:test_date) { date_in_dst }
+    let(:threepm_pdt) { test_date.time_zone.local(test_date.year, test_date.month, test_date.day, 15, 0, 0) }
+    let(:threepm_edt) { ActiveSupport::TimeZone["US/Eastern"].local(test_date.year, test_date.month, test_date.day, 15, 0, 0) }
+    let(:threepm_est) { ActiveSupport::TimeZone["US/Eastern"].local(date_not_in_dst.year, date_not_in_dst.month, date_not_in_dst.day, 15, 0, 0) }
+
+    it "handles relative times" do
+      Timecop.freeze(test_date) do
+        expect(IncidentResponse.parse_timestamp("5 minutes ago")).to eq(test_date - 5.minutes)
+      end
+    end
+
+
+    it "handles times starting with 'at'" do
+      Timecop.freeze(test_date) do
+        expect(IncidentResponse.parse_timestamp("at 3pm")).to eq threepm_pdt
+      end
+    end
+
+    it "handles times with time zones" do
+      Timecop.freeze(test_date) do
+        expect(IncidentResponse.parse_timestamp("3pm EDT")).to eq threepm_edt
+        expect(IncidentResponse.parse_timestamp("3pm -0400")).to eq threepm_edt
+      end
+    end
+
+    it "corrects 'EST' to 'EDT' during daylight time" do
+      Timecop.freeze(date_in_dst) do
+        expect(IncidentResponse.parse_timestamp("3pm EST")).to eq threepm_edt
+      end
+    end
+
+    it "corrects 'EDT' to 'EST' during standard time" do
+      Timecop.freeze(date_not_in_dst) do
+        expect(IncidentResponse.parse_timestamp("3pm EDT")).to eq threepm_est
+      end
+    end
+  end
 end

--- a/spec/models/incident_spec.rb
+++ b/spec/models/incident_spec.rb
@@ -3,4 +3,28 @@ RSpec.describe Incident do
    it { should have_many(:retrospectives) }
    it { should have_many(:remediations).through(:retrospectives) }
    it { should have_many(:timeline_entries) }
+
+   describe ".chat_start/end" do
+     let(:timestamp) { Time.now.in_time_zone('UTC') }
+     let(:incident) { create(:incident, chat_start: timestamp, chat_end: timestamp) }
+     let(:incident_from_db) { Incident.find_by(id: incident.id) }
+     let(:time_zone) { 'US/Pacific' }
+
+     before(:each) do
+       allow(Config).to receive(:time_zone).and_return(time_zone)
+     end
+
+     it "returns the correct timestamp" do
+       # Gotta use inexact comparison because the timestamp loses precision when
+       # round-tripped through the DB.  All we care is that it represents the
+       # same point in time, irrespective of time zone.
+       expect(incident_from_db.chat_start).to be_within(0.001).of timestamp
+       expect(incident_from_db.chat_end).to be_within(0.001).of timestamp
+     end
+
+     it "returns the timestamp in the configured time zone" do
+       expect(incident_from_db.chat_start.time_zone).to eq ActiveSupport::TimeZone[time_zone]
+       expect(incident_from_db.chat_end.time_zone).to eq ActiveSupport::TimeZone[time_zone]
+     end
+   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,14 +50,13 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.before do
-    DatabaseCleaner.start
-  end
-
-  config.after do
-    DatabaseCleaner.clean
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 end


### PR DESCRIPTION
Posting a WIP because folks were curious about my time zone woes.

The highlight reel:

* The old chatops stuff could handle '15:12 EDT', for example, along with natural language like "15 minutes ago".
* Ruby's canonical gem for natural language date parsing is Chronic.
* Chronic pukes on "15:12 EDT" and returns `nil`.
* I assumed this was because it couldn't parse time zones.
* I spent a very very long time trying to figure out how to parse "EDT", "PDT", "PST", etc in rails.
  * Spoiler: it's really difficult.  Indiana makes life very difficult.
* Turns out that Chronic only hates time zones [sometimes](https://github.com/mojombo/chronic/issues/134), so there's a relatively simple workaround.
* denouement: I can never remember if it's "EDT" or "EST" at any given time of the year, so I made the code pick the correct one no matter which the user says.

cc @jmervine @reidmix