### PR TITLE
timeline command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_script:
   - RAILS_ENV=test bundle exec rake db:migrate
 addons:
   postgresql: "9.4"
+language: ruby
+cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem "loggerator", require: [
   ]
 
 gem "activeadmin", "~> 1.0.0.pre4"
-gem 'inherited_resources', github: 'activeadmin/inherited_resources'
+gem 'inherited_resources', git: 'https://github.com/activeadmin/inherited_resources'
 gem 'omniauth-google-oauth2'
 gem 'rack-ssl-enforcer'
 gem 'require_all'

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'require_all'
 gem 'active_record_ignored_attributes'
 gem 'omniauth-trello'
 gem 'ruby-trello', "~> 1.5.1"
+gem 'default_value_for', '~> 3.0.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.3)
+    default_value_for (3.0.2)
+      activerecord (>= 3.2.0, < 5.1)
     diff-lcs (1.2.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
@@ -339,6 +341,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   configerator
   database_cleaner
+  default_value_for (~> 3.0.0)
   dotenv-rails
   excon (= 0.50.1)
   factory_girl_rails

--- a/app/models/timeline_entry.rb
+++ b/app/models/timeline_entry.rb
@@ -1,4 +1,8 @@
 class TimelineEntry < ApplicationRecord
   belongs_to :user
   belongs_to :incident
+
+  default_value_for :timestamp do
+    Time.now
+  end
 end

--- a/lib/generators/chatops/chatops_generator.rb
+++ b/lib/generators/chatops/chatops_generator.rb
@@ -22,7 +22,7 @@ RSpec.describe ChatOps::Commands::#{class_name}Command do
   include ChatOpsCommandHelper
 
   describe 'regex' do
-    it it_should_match_commands <<-EOL
+    it_should_match_commands <<-EOL
       # some command
       # some other command
     EOL

--- a/spec/helpers/chat_ops_command_helper.rb
+++ b/spec/helpers/chat_ops_command_helper.rb
@@ -37,17 +37,29 @@ module ChatOpsCommandHelper
   end
 
   module ContextMethods
-    def test_regex_against_commands(commands)
-      subject { described_class.regex }
+    def command(cmd)
+      define_method(cmd) do |arg=""|
+        process("#{cmd.to_s.sub('_', ' ')} #{arg}")
+      end
+    end
 
-      commands.each_line.map(&:strip).each do |command|
+    def it_should_match_commands(commands)
+      _generate_match_tests commands do |command|
         it { is_expected.to match command }
       end
     end
 
-    def command(cmd)
-      define_method(cmd) do |arg=""|
-        process("#{cmd.to_s.sub('_', ' ')} #{arg}")
+    def it_should_not_match_commands(commands)
+      _generate_match_tests commands do |command|
+        it { is_expected.not_to match command }
+      end
+    end
+
+    def _generate_match_tests(commands)
+      subject { described_class.regex }
+
+      commands.each_line.map(&:strip).each do |command|
+        yield command
       end
     end
   end

--- a/spec/lib/chat_ops/commands/add_responder_command_spec.rb
+++ b/spec/lib/chat_ops/commands/add_responder_command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ChatOps::Commands::AddResponderCommand do
   include ChatOpsCommandHelper
 
   describe 'regex' do
-    test_regex_against_commands <<-EOL
+    it_should_match_commands <<-EOL
       add person to incident
       add person and other person to incident
       add person to incident 12

--- a/spec/lib/chat_ops/commands/add_timeline_entry_command_spec.rb
+++ b/spec/lib/chat_ops/commands/add_timeline_entry_command_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe ChatOps::Commands::AddTimelineEntryCommand do
+  include ChatOpsCommandHelper
+
+  describe 'regex' do
+    it_should_match_commands <<-EOL
+      timeline foo
+      timeline foo bar baz
+      timeline 12 foo
+      timeline 12 foo bar baz
+      timeline 1is the loneliest number
+    EOL
+
+    it_should_not_match_commands <<-EOL
+      timeline 12
+    EOL
+  end
+
+  describe '.run' do
+    let(:user1) { create(:user) }
+    let(:user2) { create(:user) }
+    let!(:incident) { create(:incident,
+                            open: true,
+                            chat_start: 10.minutes.ago,
+                            timeline_start: 10.minutes.ago)
+                   }
+    let!(:other_incident) { create(:incident,
+                                  open: true,
+                                  chat_start: 20.minutes.ago,
+                                  timeline_start: 20.minutes.ago)
+                         }
+    let(:message1) { "this is a timeline entry" }
+    let(:message_with_mentions) { "timeline entry with #{user1.handle} and #{user2.name}" }
+
+    it "should add an entry to the timeline" do
+      Timecop.freeze do
+        expect(process("timeline #{message1}", user1)).to react_with(':checkmark:')
+        expect(incident.timeline_entries).to have(1).items
+        expect(incident.timeline_entries[0].message).to eq message1
+        expect(incident.timeline_entries[0].user).to be_same_as user1
+        expect(incident.timeline_entries[0].timestamp).to match_to_the_millisecond Time.now
+      end
+    end
+
+    it "should add an entry to the specified incident" do
+      process("timeline #{other_incident.incident_id} #{message1}")
+      expect(incident.timeline_entries).to be_empty
+      expect(other_incident.timeline_entries).to have(1).items
+    end
+
+    it "should add the user running the command to the incident" do
+      process("timeline #{message1}", user1)
+      expect(incident.responders).to include user1
+    end
+
+    it "should add mentioned users to the incident's responders list" do
+      process("timeline #{message_with_mentions}")
+      expect(incident.responders).to include(user1, user2)
+    end
+  end
+end

--- a/spec/lib/chat_ops/commands/end_incident_command_spec.rb
+++ b/spec/lib/chat_ops/commands/end_incident_command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ChatOps::Commands::EndIncidentCommand do
   include ChatOpsCommandHelper
 
   describe "regex" do
-    test_regex_against_commands <<-EOL
+    it_should_match_commands <<-EOL
       end incident
       end the incident
       end incident 12

--- a/spec/lib/chat_ops/commands/list_responder_command_spec.rb
+++ b/spec/lib/chat_ops/commands/list_responder_command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ChatOps::Commands::ListResponderCommand do
   include ChatOpsCommandHelper
 
   describe 'regex' do
-    test_regex_against_commands <<-EOL
+    it_should_match_commands <<-EOL
       incident responders
       incident 13 responders
     EOL

--- a/spec/lib/chat_ops/commands/remove_responder_command_spec.rb
+++ b/spec/lib/chat_ops/commands/remove_responder_command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ChatOps::Commands::RemoveResponderCommand do
   include ChatOpsCommandHelper
 
   describe 'regex' do
-    test_regex_against_commands <<-EOL
+    it_should_match_commands <<-EOL
       remove person from incident
       remove person and other person from incident
       remove person from incident 12

--- a/spec/lib/chat_ops/commands/start_incident_command_spec.rb
+++ b/spec/lib/chat_ops/commands/start_incident_command_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe ChatOps::Commands::StartIncidentCommand do
   include ChatOpsCommandHelper
 
   describe "regex" do
-    test_regex_against_commands <<-EOL
+    it_should_match_commands <<-EOL
       start incident
       start an incident
       start incident 900


### PR DESCRIPTION
Adds the 'timeline <message>' command + tests.

Collateral damage:

- Made `TimelineEntry` set its `timestamp` to `Time.now` by default (using `default_value_for` gem)
- changed `test_regex_matches_commands` to `it_should_match_commands`
- added `it_should_not_match_commands`

cc @joshuatobin 
