### PR TITLE
DRY incident ID parsing in commands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/activeadmin/inherited_resources.git
+  remote: https://github.com/activeadmin/inherited_resources
   revision: 4434f0ae72f790cf371728838c927c338100555d
   specs:
     inherited_resources (1.6.0)

--- a/lib/chat_ops/commands/add_responder_command.rb
+++ b/lib/chat_ops/commands/add_responder_command.rb
@@ -1,6 +1,7 @@
 module ChatOps::Commands
   class AddResponderCommand < ChatOps::ChatOpsCommand
     match /add\s+(?<who>.*)\s+to\s+incident(\s+(?<incident_id>\d+))?/
+    parse_incident true
     help_message "h add <person> [<person>...] to incident -- <person> can be a full name or @handle"
 
     def run(user, match, incident)

--- a/lib/chat_ops/commands/add_responder_command.rb
+++ b/lib/chat_ops/commands/add_responder_command.rb
@@ -3,9 +3,7 @@ module ChatOps::Commands
     match /add\s+(?<who>.*)\s+to\s+incident(\s+(?<incident_id>\d+))?/
     help_message "h add <person> [<person>...] to incident -- <person> can be a full name or @handle"
 
-    def run(user, match)
-      incident = ChatOps.determine_incident(match['incident_id']) or return ChatOps.unknown_incident
-
+    def run(user, match, incident)
       responders = ChatOps.get_mentioned_users(match['who'])
       return ChatOps.error("Person not found.  Try using their @handle.") if responders.length == 0
 

--- a/lib/chat_ops/commands/add_timeline_entry_command.rb
+++ b/lib/chat_ops/commands/add_timeline_entry_command.rb
@@ -31,12 +31,10 @@ module ChatOps::Commands
                 (?<message>.*)
               )
             }ix
-
+    parse_incident true
     help_message "h timeline [#] <message> - adds a message to the timeline for the specified incident (or the current incident if no ID is specified)"
 
-    def run(user, match)
-      incident = ChatOps.determine_incident(match[:incident_id]) or return ChatOps.unknown_incident
-
+    def run(user, match, incident)
       ChatOps.get_mentioned_users(match[:message]).each do |responder|
         incident.responders << responder
       end

--- a/lib/chat_ops/commands/end_incident_command.rb
+++ b/lib/chat_ops/commands/end_incident_command.rb
@@ -3,9 +3,7 @@ module ChatOps::Commands
     match /end\s+(the\s+)?incident(\s+(?<incident_id>[0-9]+))?/
     help_message "end incident [#] - sets the end of chat for an incident"
 
-    def run(user, match)
-      incident = ChatOps.determine_incident(match['incident_id']) or return ChatOps.unknown_incident
-
+    def run(user, match, incident)
       incident.chat_end = Time.now
       incident.save
 

--- a/lib/chat_ops/commands/end_incident_command.rb
+++ b/lib/chat_ops/commands/end_incident_command.rb
@@ -1,6 +1,7 @@
 module ChatOps::Commands
   class EndIncidentCommand < ChatOps::ChatOpsCommand
     match /end\s+(the\s+)?incident(\s+(?<incident_id>[0-9]+))?/
+    parse_incident true
     help_message "end incident [#] - sets the end of chat for an incident"
 
     def run(user, match, incident)

--- a/lib/chat_ops/commands/list_responder_command.rb
+++ b/lib/chat_ops/commands/list_responder_command.rb
@@ -1,11 +1,10 @@
 module ChatOps::Commands
   class ListResponderCommand < ChatOps::ChatOpsCommand
     match /incident(\s+(?<incident_id>\d+))?\s+responders/
+    parse_incident true
     help_message "h incident [#] responders - list responders for an incident"
 
-    def run(user, match)
-      incident = ChatOps.determine_incident(match['incident_id']) or return ChatOps.unknown_incident
-
+    def run(user, match, incident)
       ChatOps.message("Incident responders for incident #{incident.incident_id}: #{incident.responders.map(&:name).join(", ")}")
     end
   end

--- a/lib/chat_ops/commands/remove_responder_command.rb
+++ b/lib/chat_ops/commands/remove_responder_command.rb
@@ -1,11 +1,10 @@
 module ChatOps::Commands
   class RemoveResponderCommand < ChatOps::ChatOpsCommand
     match /remove\s+(?<who>.*)\s+from\s+incident(\s+(?<incident_id>\d+))?/
+    parse_incident true
     help_message "h remove <person> [<person>...] from incident -- <person> can be a full name or @handle"
 
-    def run(user, match)
-      incident = ChatOps.determine_incident(match['incident_id']) or return ChatOps.unknown_incident
-
+    def run(user, match, incident)
       responders = ChatOps.get_mentioned_users(match['who'])
       return ChatOps.error("Person not found.  Try using their @handle.") if responders.length == 0
 

--- a/lib/generators/chatops/chatops_generator.rb
+++ b/lib/generators/chatops/chatops_generator.rb
@@ -36,7 +36,7 @@ RSpec.describe ChatOps::Commands::#{class_name}Command do
 
   describe '.run' do
     it "tests some thing" do
-      # expect(process("add @#{user1.handle} to incident")).to react_with(':checkmark:').and not_have_message
+      # expect(process("add @\#{user1.handle} to incident")).to react_with(':checkmark:').and not_have_message
     end
   end
 end

--- a/lib/generators/chatops/chatops_generator.rb
+++ b/lib/generators/chatops/chatops_generator.rb
@@ -8,7 +8,13 @@ module ChatOps::Commands
     match //
     help_message ""
 
-    def run(user, match)
+    # A command can request that an optional incident ID be parsed
+    # automatically by setting this to true.  Add (?<incident_id>\d+)? in the
+    # match regex above and the incident will be looked up and passed in to
+    # run().
+    parse_incident false
+
+    def run(user, match, incident=nil)
       # ChatOps.message()
     end
   end


### PR DESCRIPTION
Move parsing of incident ID to ChatOpsCommand.  If a command's `run` method takes a parameter `incident`, then ChatOpsCommand will parse the incident id (or default to the current incident) and pass it into the command.  This is a big win for DRYing incident commands.

cc @joshuatobin 