### PR TITLE
Fixes bug for uninitialized constant

### DIFF
--- a/app/controllers/api/v1/chat_ops_controller.rb
+++ b/app/controllers/api/v1/chat_ops_controller.rb
@@ -25,6 +25,4 @@ class Api::V1::ChatOpsController < ApplicationController
   def message_params
     params.require(:message)
   end
-
-  require_all 'lib/chat_ops/commands/**.rb'
 end

--- a/app/controllers/api/v1/chat_ops_controller.rb
+++ b/app/controllers/api/v1/chat_ops_controller.rb
@@ -25,4 +25,6 @@ class Api::V1::ChatOpsController < ApplicationController
   def message_params
     params.require(:message)
   end
+
+  require_all 'lib/chat_ops/commands/**.rb'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,7 @@ Bundler.require(*Rails.groups)
 
 module Retrodot
   class Application < Rails::Application
-    config.autoload_paths   += %W( #{config.root}/lib )
-    config.autoload_paths   += %W( #{config.root}/lib/chat_ops )
+    config.autoload_paths += %W( #{config.root}/lib #{config.root}/lib/chat_ops )
 
     # Eager loading works differently in production
     # Ensure chat_ops is loaded so rails boots properly.

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,8 @@ module Retrodot
   class Application < Rails::Application
 #    config.autoload_paths << Rails.root.join('lib')
 #    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
-    config.eager_load_paths << Rails.root.join('lib', 'chat_ops')
+    #config.eager_load_paths << Rails.root.join('lib', 'chat_ops')
+    config.paths.add "lib/chat_ops", eager_load: true
     #config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,11 @@ Bundler.require(*Rails.groups)
 
 module Retrodot
   class Application < Rails::Application
-    config.autoload_paths << Rails.root.join('lib')
-    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
+    config.autoload_paths   += %W( #{config.root}/lib )
+    config.autoload_paths   += %W( #{config.root}/lib/chat_ops )
+
+    # Eagar loading works differently in production so we have to
+    # load chatops to load rails properly
     config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,11 +8,8 @@ Bundler.require(*Rails.groups)
 
 module Retrodot
   class Application < Rails::Application
-#    config.autoload_paths << Rails.root.join('lib')
-#    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
-    #config.eager_load_paths << Rails.root.join('lib', 'chat_ops')
-    #config.paths.add "lib/chat_ops", eager_load: true
-    config.eager_load_paths.unshift("#{config.root}/lib/chat_ops")
-    #config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
+    config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
+    config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module Retrodot
     config.autoload_paths   += %W( #{config.root}/lib )
     config.autoload_paths   += %W( #{config.root}/lib/chat_ops )
 
-    # Eagar loading works differently in production so we have to
+    # Eager loading works differently in production so we have to
     # load chatops to load rails properly
     config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,8 @@ module Retrodot
     config.autoload_paths   += %W( #{config.root}/lib )
     config.autoload_paths   += %W( #{config.root}/lib/chat_ops )
 
-    # Eager loading works differently in production so we have to
-    # load chatops to load rails properly
+    # Eager loading works differently in production
+    # Ensure chat_ops is loaded so rails boots properly.
     config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,6 @@ module Retrodot
   class Application < Rails::Application
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join('lib', 'chat_ops')
+    config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,8 +8,9 @@ Bundler.require(*Rails.groups)
 
 module Retrodot
   class Application < Rails::Application
-    config.autoload_paths << Rails.root.join('lib')
-    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
-    config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
+#    config.autoload_paths << Rails.root.join('lib')
+#    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
+    config.eager_load_paths << Rails.root.join('lib', 'chat_ops')
+    #config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,8 @@ module Retrodot
 #    config.autoload_paths << Rails.root.join('lib')
 #    config.autoload_paths << Rails.root.join('lib', 'chat_ops')
     #config.eager_load_paths << Rails.root.join('lib', 'chat_ops')
-    config.paths.add "lib/chat_ops", eager_load: true
+    #config.paths.add "lib/chat_ops", eager_load: true
+    config.eager_load_paths.unshift("#{config.root}/lib/chat_ops")
     #config.eager_load_paths += %W( #{config.root}/lib/chat_ops )
   end
 end


### PR DESCRIPTION
I'm getting an uninitialized constant in staging, but not locally. Opening this up as a discussion starting point. 

```
 Started POST "/api/v1/chat_ops/respond" for ...
Processing by Api::V1::ChatOpsController#respond as JSON
...
Completed 500 Internal Server Error in 34ms (ActiveRecord: 10.2ms)
NameError (uninitialized constant Api::V1::ChatOpsController::ChatOps):
app/controllers/api/v1/chat_ops_controller.rb:11:in `respond'
```

CC: @lexelby @reidmix 