### PR TITLE
Adding omniauth-slack support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'default_value_for', '~> 3.0.0'
 gem 'google-api-client', '~> 0.9.15'
 gem 'googleauth'
 
+# The upstream maintained version doesn't support signin with slack.
+gem 'omniauth-slack', git: 'https://github.com/joshuatobin/omniauth-slack', branch: 'signin-with-slack-support'
+
 group :development, :test do
   gem 'rspec-collection_matchers'
   gem 'shoulda'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       railties (>= 3.2, < 5.1)
       responders
 
+GIT
+  remote: https://github.com/joshuatobin/omniauth-slack
+  revision: 13ec33c2bded9f5f89318e3913079b85775fbf1e
+  branch: signin-with-slack-support
+  specs:
+    omniauth-slack (2.3.0)
+      omniauth-oauth2 (~> 1.3.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -68,7 +76,7 @@ GEM
     addressable (2.4.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
-    arel (7.1.2)
+    arel (7.1.4)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -118,7 +126,7 @@ GEM
     formtastic_i18n (0.6.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    google-api-client (0.9.15)
+    google-api-client (0.9.18)
       addressable (~> 2.3)
       googleauth (~> 0.5)
       httpclient (~> 2.7)
@@ -147,13 +155,13 @@ GEM
       actionpack (>= 4.1, < 5.1)
       activesupport (>= 4.1, < 5.1)
     hashdiff (0.3.0)
-    hashie (3.4.4)
+    hashie (3.4.6)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
       nokogiri (~> 1.6.0)
       ruby_parser (~> 3.5)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.2.4)
     hurley (0.2)
@@ -168,7 +176,7 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (2.0.2)
-    jwt (1.5.4)
+    jwt (1.5.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -177,7 +185,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     little-plugger (1.1.4)
-    loggerator (0.0.1)
+    loggerator (0.0.2)
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
@@ -189,15 +197,14 @@ GEM
     method_source (0.8.2)
     mime-types (2.99.3)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (1.2.1)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     oauth (0.5.1)
     oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
@@ -216,7 +223,7 @@ GEM
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
-    omniauth-oauth2 (1.4.0)
+    omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     omniauth-trello (0.0.4)
@@ -225,8 +232,7 @@ GEM
       omniauth (~> 1.0)
       omniauth-oauth (~> 1.0)
     os (0.9.6)
-    pg (0.18.4)
-    pkg-config (1.1.7)
+    pg (0.19.0)
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     pry (0.10.4)
@@ -271,7 +277,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.2.2)
+    rake (11.3.0)
     ransack (1.8.2)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -293,7 +299,7 @@ GEM
     retriable (2.1.0)
     rspec-collection_matchers (1.1.2)
       rspec-expectations (>= 2.99.0.beta1)
-    rspec-core (3.5.3)
+    rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -316,8 +322,8 @@ GEM
       json
       oauth (>= 0.4.5)
       rest-client (~> 1.8.0)
-    ruby_dep (1.4.0)
-    ruby_parser (3.8.2)
+    ruby_dep (1.5.0)
+    ruby_parser (3.8.3)
       sexp_processor (~> 4.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
@@ -340,10 +346,11 @@ GEM
       jwt (~> 1.5)
       multi_json (~> 1.10)
     slop (3.6.0)
-    spring (1.7.2)
-    spring-watcher-listen (2.0.0)
+    spring (2.0.0)
+      activesupport (>= 4.2)
+    spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
-      spring (~> 1.2)
+      spring (>= 1.2, < 3.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -396,6 +403,7 @@ DEPENDENCIES
   jquery-rails
   loggerator
   omniauth-google-oauth2
+  omniauth-slack!
   omniauth-trello
   pg (~> 0.18)
   pry-byebug (~> 1.3.3)
@@ -423,4 +431,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -58,19 +58,12 @@ class AuthController < ApplicationController
 
   def install_slack
     redirect_to failure_auth_path and return unless current_user
+    current_user.update(slack_access_token: omniauth_info["credentials"]["token"])
 
-    update_slack_token
-    flash[:notice] = "Updated slack token"
-
-    redirect_to root_path
+    redirect_to root_path, notice: "Updated slack token"
   end
 
   protected
-
-  def update_slack_token
-    current_user.update(slack_access_token: omniauth_info["credentials"]["token"])
-  end
-
   def update_google_creds
     creds = omniauth_info["credentials"]
     current_user.update(google_refresh_token: creds[:refresh_token]) if !!creds[:refresh_token]

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -6,12 +6,12 @@ class AuthController < ApplicationController
   def callback
     log(fn: 'callback')
     unless session['user'].present?
-      user  = request.env['omniauth.auth']['info']
-      email = (user['email']||'').downcase
-      name  = user['name']
+      user  = omniauth_info["info"]
+      email = (user["email"]||"").downcase
+      name  = user["name"]
 
-      if params['provider'] != 'developer' && !valid_email?(email)
-        log(fn: 'callback', at: 'failure')
+      if params["provider"] != "developer" && !valid_email?(email)
+        log(fn: "callback", at: "failure")
 
         redirect_to failure_auth_path
         return
@@ -22,7 +22,7 @@ class AuthController < ApplicationController
       # The update ensures that their name in Retrodot is synced with changes in the oauth provider.
       User.create_with(name: name).find_or_create_by(email: email).update(name: name)
 
-      flash[:notice] = 'Logged in.'
+      flash[:notice] = "Logged in."
     end
 
     update_google_creds unless developer?
@@ -45,7 +45,7 @@ class AuthController < ApplicationController
   end
 
   def failure
-    render plain: 'You are not authorized', status: 401
+    render plain: "You are not authorized", status: 401
   end
 
   def verify
@@ -53,14 +53,28 @@ class AuthController < ApplicationController
   end
 
   def developer?
-    request.env['omniauth.auth']['provider'] == "developer"
+    omniauth_info["provider"] == "developer"
+  end
+
+  def install_slack
+    redirect_to failure_auth_path and return unless current_user
+
+    update_slack_token
+    flash[:notice] = "Updated slack token"
+
+    redirect_to root_path
   end
 
   protected
 
+  def update_slack_token
+    current_user.update(slack_access_token: omniauth_info["credentials"]["token"])
+  end
+
   def update_google_creds
-    creds = request.env['omniauth.auth']['credentials']
+    creds = omniauth_info["credentials"]
     current_user.update(google_refresh_token: creds[:refresh_token]) if !!creds[:refresh_token]
+
     current_user.update(google_auth_code: params[:code])
   end
 
@@ -70,5 +84,9 @@ class AuthController < ApplicationController
 
   def valid_email? email
     !!(email =~ %r[@#{Config.google_domain}$])
+  end
+
+  def omniauth_info
+    request.env["omniauth.auth"]
   end
 end

--- a/config/config.rb
+++ b/config/config.rb
@@ -42,9 +42,8 @@ module Config
   optional :trello_consumer_key, string
   optional :trello_consumer_secret, string
   optional :trello_template, string
-
   optional :chatops_prefix, string
-  
+
   # Google Script id for rest execution API
   # https://developers.google.com/apps-script/execution
   optional :google_script_id, string
@@ -56,4 +55,7 @@ module Config
   optional :smtp_domain, string
   optional :smtp_login, string
   optional :smtp_password, string
+
+  optional :slack_client_id, string
+  optional :slack_client_secret, string
 end

--- a/config/initializers/log.rb
+++ b/config/initializers/log.rb
@@ -1,2 +1,2 @@
-Loggerator.default_context = { app: Config.app_name }
-Loggerator::Metrics.name   = Config.app_name
+Loggerator::Log.default_context = { app: Config.app_name }
+Loggerator::Metrics.name        = Config.app_name

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -11,4 +11,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
                 https://www.googleapis.com/auth/script.external_request]
     }
   provider :trello, Config.trello_consumer_key, Config.trello_consumer_secret, app_name: Config.app_name, scope: "read,write,account", expiration: "never"
+  provider :slack,  Config.slack_client_id, Config.slack_client_secret, scope: "identify,commands,team:read", name: :slack_install
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
 
   get '/auth/trello/callback', to: 'trello#create'
 
+  # Slack callack for token creation
+  get  "/auth/slack_install/callback", to: "auth#install_slack"
+
   resource :auth, controller: 'auth', only: :index do
     match "/:provider/callback" => "auth#callback", via: %i[get post]
     get :logout, as: 'logout'

--- a/db/migrate/20161012151836_add_slack_access_token_to_user.rb
+++ b/db/migrate/20161012151836_add_slack_access_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddSlackAccessTokenToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :slack_access_token, :string
+  end
+end


### PR DESCRIPTION
Adds support for installing slack and adding an oauth token. The token will be attached to one user and will make requests "on behalf of" other users. 

CC: @reidmix @lexelby 