### PR TITLE
Show started_at / resolved_at in the UI

### DIFF
--- a/app/admin/incident.rb
+++ b/app/admin/incident.rb
@@ -89,8 +89,8 @@ ActiveAdmin.register Incident do
   index do
     selectable_column
     column :incident_id
-    column :created_at
-    column :updated_at
+    column :started_at
+    column :resolved_at
     column :state
     column :duration
     column :title

--- a/app/admin/incident.rb
+++ b/app/admin/incident.rb
@@ -7,6 +7,8 @@ class TrelloAuthRequired < StandardError; end
 ActiveAdmin.register Incident do
   config.sort_order = 'incident_id_desc'
 
+  filter :responders, collection: proc { Incident.all.map { |i| i.responders.map(&:name).compact}.flatten.uniq }
+
   menu priority: 1
 
   permit_params :category_id

--- a/app/admin/incident.rb
+++ b/app/admin/incident.rb
@@ -7,6 +7,7 @@ class TrelloAuthRequired < StandardError; end
 ActiveAdmin.register Incident do
   config.sort_order = 'incident_id_desc'
 
+  preserve_default_filters!
   filter :responders, collection: proc { Incident.all.map { |i| i.responders.map(&:name).compact}.flatten.uniq }
 
   menu priority: 1


### PR DESCRIPTION
Feedback from @peculiaire to show `started_at` / `resolved_at` vs `created_at` / `updated_at` in the admin UI. 

CC: @lexelby @reidmix 
