### PR TITLE
remove test Command subclasses from ChatOps.command after each test

### DIFF
--- a/spec/lib/chat_ops/chat_ops_spec.rb
+++ b/spec/lib/chat_ops/chat_ops_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ChatOps do
-  let!(:commands) { ChatOps.commands }
+  let!(:commands) { ChatOps.commands.dup }
   before { ChatOps.class_variable_set :@@commands, [] }
   after { ChatOps.class_variable_set :@@commands, commands }
 

--- a/spec/lib/chat_ops/command_spec.rb
+++ b/spec/lib/chat_ops/command_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe ChatOps::Command do
   let(:recent_incident) { create(:incident, timeline_start: 1.hour.ago, chat_start: 1.hour.ago, timeline_entries: [{timestamp: 1.minute.ago}]) }
   let(:open_incident) { create(:incident, state: "open", timeline_start: 1.hour.ago) }
 
+  # Clean up ChatOps.commands after we're done so that other tests don't see the
+  # Command subclasses we make in these tests.
+  let!(:commands) { ChatOps.commands.dup}
+  after { ChatOps.class_variable_set :@@commands, commands }
 
   # Helper method to set up a Command subclass with match regex, parse_incident,
   # and an optional definition of the `run` method by passing a block.


### PR DESCRIPTION
In `spec/lib/chat_ops/command_spec.rb`, we create subclasses of `Command`.  They get registered in `ChatOps.commands` and persist after the test completes, which can break other tests.  This PR saves `ChatOps.commands` and restores it after each test.

`spec/lib/chat_ops/chat_ops_spec.rb` already had code to do this, but it was buggy -- it should save a copy of `ChatOps.commands` instead of the actual Array object.

@joshuatobin  this fixes the bug you ran into: https://github.com/heroku/retrodot/pull/90#discussion_r86203836